### PR TITLE
Enable Easypost to handle trade-in shipments

### DIFF
--- a/app/decorators/controllers/cart_line_items_controller_decorator.rb
+++ b/app/decorators/controllers/cart_line_items_controller_decorator.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Spree
+  module Api
+    module CartLineItemsControllerDecorator
+      def create
+        @order = current_order(create_order_if_necessary: true)
+        authorize! :update, @order, cookies.signed[:guest_token]
+
+        variant  = Spree::Variant.find(params[:variant_id])
+        quantity = params[:quantity].present? ? params[:quantity].to_i : 1
+
+        customer_metadata = params.require(:customer_metadata).permit! if params[:customer_metadata].present?
+        # 2,147,483,647 is crazy. See issue https://github.com/spree/spree/issues/2695.
+        if quantity.between?(1, 2_147_483_647)
+          begin
+            @line_item = @order.contents.add(variant, quantity)
+            if customer_metadata.present?
+              customer_metadata.each do |key, value|
+                unique_key = "#{key}_#{SecureRandom.hex(4)}"
+                @line_item.customer_metadata[unique_key] = value
+              end
+              @line_item.save
+            end
+          rescue ActiveRecord::RecordInvalid => e
+            @order.errors.add(:base, e.record.errors.full_messages.join(", "))
+          end
+        else
+          @order.errors.add(:base, t('spree.please_enter_reasonable_quantity'))
+        end
+
+        respond_to do |format|
+          format.html do
+            if @order.errors.any?
+              flash[:error] = @order.errors.full_messages.join(", ")
+              redirect_back_or_default(root_path)
+              return
+            else
+              redirect_to cart_path
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+CartLineItemsController.prepend(Spree::Api::CartLineItemsControllerDecorator)

--- a/app/decorators/models/solidus_easypost/spree/order_decorator.rb
+++ b/app/decorators/models/solidus_easypost/spree/order_decorator.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Spree
+  module OrderDecorator
+    def self.prepended(base)
+      base.state_machine.after_transition to: :complete, do: :generate_labels
+    end
+
+    def payment_required?
+      # First, check the existing condition: if total is 0 or less, no payment is needed.
+      return false unless total > 0
+
+      # Collect all products from the order's line items.
+      products = line_items.map { |li| li.variant.product }
+
+      # Check if any product has a product_type value of 2 (trade-in).
+      trade_in_present = products.any?(&:trade_in?)
+
+      # Check if any product has a product_type value that is not 2.
+      other_product_present = products.any? { |product| !product.trade_in? }
+
+      # If both trade-in and non trade-in products are present, raise an error.
+      if trade_in_present && other_product_present
+        raise "Invalid order: cannot mix trade-in and non trade-in products."
+      end
+
+      # If only trade-in products are present, payment is not required.
+      return false if trade_in_present
+
+      # Otherwise, payment is required.
+      true
+    end
+
+    private
+
+    def generate_labels
+      shipments.each(&:label_for_complete_order)
+      shipments.each(&:generate_inbound_roundtrip_labels)
+    end
+  end
+end
+
+Spree::Order.prepend(Spree::OrderDecorator)

--- a/app/decorators/models/solidus_easypost/spree/shipment_decorator.rb
+++ b/app/decorators/models/solidus_easypost/spree/shipment_decorator.rb
@@ -4,11 +4,20 @@ module SolidusEasypost
   module Spree
     module ShipmentDecorator
       def self.prepended(base)
-        base.state_machine.before_transition(
-          to: :shipped,
-          do: :buy_easypost_rate,
-          if: -> { SolidusEasypost.configuration.purchase_labels }
-        )
+        # Previous flow was to create postage labels once the shipment is shipped
+        # Now we are moving it to order complete is it expected?
+
+        # base.state_machine.before_transition(
+        #   to: :shipped,
+        #   do: :buy_easypost_rate,
+        #   if: -> { SolidusEasypost.configuration.purchase_labels }
+        # )
+
+        # base.state_machine.after_transition(
+        #   to: :shipped,
+        #   do: :generate_inbound_roundtrip_labels,
+        #   if: -> { SolidusEasypost.configuration.purchase_labels }
+        # )
 
         base.delegate(
           :easy_post_rate_id,
@@ -29,6 +38,15 @@ module SolidusEasypost
         easypost_shipment&.postage_label&.label_url
       end
 
+      def generate_inbound_roundtrip_labels
+        generate_inbound_label
+        generate_return_label
+      end
+
+      def label_for_complete_order
+        buy_easypost_rate
+      end
+
       private
 
       def buy_easypost_rate
@@ -36,6 +54,7 @@ module SolidusEasypost
         return if tracking
 
         easypost_shipment_id = easypost_shipment.id
+
         rate = easypost_shipment.rates.find do |easypost_rate|
           easypost_rate.id == selected_easy_post_rate_id
         end
@@ -47,6 +66,97 @@ module SolidusEasypost
         )
 
         self.tracking = easypost_shipment.tracking_code
+      end
+
+      def generate_inbound_label
+        return if order.customer_metadata[:inbound_label_url].present?
+
+        from_address = SolidusEasypost::AddressBuilder.from_address(order.ship_address)
+        to_address = SolidusEasypost::AddressBuilder.from_stock_location(service_stock_location)
+
+        options = {
+          from_address_options: from_address,
+          to_address_options: to_address
+        }
+
+        inbound_shipment = SolidusEasypost::ShipmentBuilder.from_package(to_package, options)
+        rate = inbound_shipment.lowest_rate
+        purchased_shipment = SolidusEasypost.client.shipment.buy(inbound_shipment.id, rate: { id: rate.id })
+
+        # Create pickup using extracted methods
+        pickup_details = create_easypost_pickup(purchased_shipment, from_address)
+
+        order.update!(
+          customer_metadata: (order.customer_metadata || {}).merge(
+            inbound_label_url: purchased_shipment.postage_label.label_url,
+            pickup_id: pickup_details[:pickup].id,
+            pickup_status: pickup_details[:pickup].status,
+            pickup_min_datetime: pickup_details[:min_datetime],
+            pickup_max_datetime: pickup_details[:max_datetime]
+          )
+        )
+      rescue StandardError => e
+        Rails.logger.error "Failed to generate inbound label or create pickup: #{e.message}"
+        raise e
+      end
+
+      def generate_return_label
+        return if order.admin_metadata[:return_label_url].present?
+
+        from_address = SolidusEasypost::AddressBuilder.from_stock_location(service_stock_location)
+        to_address = SolidusEasypost::AddressBuilder.from_address(order.ship_address)
+
+        options = {
+          from_address_options: from_address,
+          to_address_options: to_address
+        }
+
+        return_shipment = SolidusEasypost::ShipmentBuilder.from_package(to_package, options)
+        rate = return_shipment.lowest_rate
+        return_label = SolidusEasypost.client.shipment.buy(return_shipment.id, rate: { id: rate.id })
+
+        order.update!(admin_metadata: order.admin_metadata.merge(
+          return_label_url: return_label.postage_label.label_url
+        ))
+      rescue StandardError => e
+        Rails.logger.error "Failed to generate return label: #{e.message}"
+      end
+
+      # Need to decide a way to find the stock location
+      def service_stock_location
+        @service_stock_location ||= order.variants.first.product&.service_stock_location || order.variants.first.stock_locations.first
+      end
+
+      def create_easypost_pickup(purchased_shipment, from_address)
+        # Parse pickup details
+        pickup_day = Date.parse(customer_metadata['pickup_day'])
+        start_time_str, end_time_str = customer_metadata['pickup_time'].split('-')
+
+        # Create datetime objects
+        min_datetime, max_datetime = build_pickup_datetimes(pickup_day, start_time_str, end_time_str)
+
+        # Create and return pickup details
+        {
+          pickup: SolidusEasypost.client.pickup.create(
+            address: from_address,
+            shipment: purchased_shipment.id,
+            min_datetime: min_datetime.iso8601,
+            max_datetime: max_datetime.iso8601,
+            instructions: "Please contact customer for pickup details."
+          ),
+          min_datetime: min_datetime,
+          max_datetime: max_datetime
+        }
+      end
+
+      def build_pickup_datetimes(pickup_day, start_time_str, end_time_str)
+        min_time = Time.zone.parse(start_time_str)
+        max_time = Time.zone.parse(end_time_str)
+
+        [
+          pickup_day.to_time.change(hour: min_time.hour, min: min_time.min),
+          pickup_day.to_time.change(hour: max_time.hour, min: max_time.min)
+        ]
       end
 
       ::Spree::Shipment.prepend self

--- a/app/decorators/models/solidus_easypost/spree/shipping_category_decorator.rb
+++ b/app/decorators/models/solidus_easypost/spree/shipping_category_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Spree
+  module ShippingCategoryDecorator
+    def self.prepended(base)
+      base.enum :carrier_platform, { none: 0, easypost: 1 }, prefix: true
+      base.enum :shipping_type, { normal: 0, advanced: 1, roundtrip: 2, inbound: 3, inboundroundtrip: 4 }
+      base.enum :label_creation, { normal: 0, advanced: 1 }, prefix: true
+    end
+  end
+end
+
+Spree::ShippingCategory.prepend(Spree::ShippingCategoryDecorator)

--- a/app/overrides/solidus_easypost/add_requires_identifier_to_product_form.rb
+++ b/app/overrides/solidus_easypost/add_requires_identifier_to_product_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SolidusEasypost
+  module AddRequiresIdentifierToProductForm
+    Deface::Override.new(
+      virtual_path: 'spree/admin/products/_form',
+      name: 'add_requires_identifier_field',
+      insert_after: "[data-hook='admin_product_form_track_inventory']",
+      partial: 'spree/admin/products/product_require_identifier_field'
+    )
+  end
+end

--- a/app/overrides/solidus_easypost/add_schedule_pickup_to_admin_shipping_method_form.rb
+++ b/app/overrides/solidus_easypost/add_schedule_pickup_to_admin_shipping_method_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SolidusEasypost
+  module AddSchedulePickupToAdminShippingMethodForm
+    Deface::Override.new(
+      virtual_path: 'spree/admin/shipping_methods/_form',
+      name: 'add_schedule_pick',
+      insert_after: "[data-hook='admin_shipping_method_form_fields']",
+      partial: 'spree/admin/shipping_methods/schedule_pickup'
+    )
+  end
+end

--- a/app/overrides/solidus_easypost/add_shipping_type_to_admin_shipping_category_form.rb
+++ b/app/overrides/solidus_easypost/add_shipping_type_to_admin_shipping_category_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SolidusEasypost
+  module AddShippingTypeToAdminShippingCategoryForm
+    Deface::Override.new(
+      virtual_path: 'spree/admin/shipping_categories/_form',
+      name: 'add_shipping_type_field',
+      insert_after: "[data-hook='name']",
+      partial: 'spree/admin/shipping_categories/shipping_fields'
+    )
+  end
+end

--- a/app/views/checkouts/steps/delivery_step/_pickup_fields.html.erb
+++ b/app/views/checkouts/steps/delivery_step/_pickup_fields.html.erb
@@ -1,0 +1,50 @@
+<% if form.object.shipping_methods.any?(&:schedule_pickup) %>
+<div class="pickup-fields mt-6">
+  <%= form.fields_for :customer_metadata, @order.customer_metadata || {} do |meta| %>
+    <%
+      # Calculate days and default day
+      days_options = (1..14).each_with_object([]) do |i, days|
+        date = (Date.current + 1) + i.days
+        next if date.saturday? || date.sunday?
+        days << [date.strftime("%A, %B %d"), date.iso8601] if days.count < 5
+      end.compact
+      default_day = days_options.first&.second
+    %>
+
+    <div class="field">
+      <%= meta.label :pickup_day, 'Pickup Day*', class: "block font-medium mb-1" %>
+      <%= meta.select :pickup_day,
+            options_for_select(
+              days_options,
+              @order.customer_metadata['pickup_day'] || default_day
+            ),
+            { required: true },
+            class: "w-full p-2 border rounded",
+            data: { pickup_field: true } %>
+      <small class="text-gray-500 block mt-1">Next 5 business days</small>
+    </div>
+
+    <%
+      # Calculate times and default time
+      time_options = (9..20).step(3).each_with_object([]) do |h, times|
+        next if h + 3 > 20
+        times << ["#{h}:00 - #{h+3}:00", "#{h}:00-#{h+3}:00"]
+      end
+      default_time = time_options.first&.second
+    %>
+
+    <div class="field mt-4">
+      <%= meta.label :pickup_time, 'Pickup Time*', class: "block font-medium mb-1" %>
+      <%= meta.select :pickup_time,
+            options_for_select(
+              time_options,
+              @order.customer_metadata['pickup_time'] || default_time
+            ),
+            { required: true },
+            class: "w-full p-2 border rounded",
+            data: { pickup_field: true } %>
+      <small class="text-gray-500 block mt-1">Available time slots</small>
+    </div>
+  <% end %>
+</div>
+<% end %>

--- a/app/views/orders/shared/_shipping_label.html.erb
+++ b/app/views/orders/shared/_shipping_label.html.erb
@@ -1,0 +1,5 @@
+<% if order.customer_metadata["inbound_label_url"].present? %>
+  <p>
+    <%= link_to t('spree.download_shipping_label'), order.customer_metadata["inbound_label_url"], target: '_blank' %>
+  </p>
+<% end %>

--- a/app/views/products/_serial_number_label.html.erb
+++ b/app/views/products/_serial_number_label.html.erb
@@ -1,0 +1,5 @@
+<% if product.requires_identifier %>
+  <%= label_tag :customer_metadata_value, "Serial Number or IMEI" %>
+  <p>Note: If you want the shipment to be insured, please provide a Serial Number or IMEI for your product.</p>
+  <%= text_field_tag "customer_metadata[user_serial_number]", nil, placeholder: "Enter IMEI", class: 'min-w-[200px] mb-5' %>
+<% end %>

--- a/app/views/spree/admin/products/_product_require_identifier_field.html.erb
+++ b/app/views/spree/admin/products/_product_require_identifier_field.html.erb
@@ -1,0 +1,8 @@
+<div data-hook="admin_product_form_track_inventory">
+  <%= f.field_container :requires_identifier do %>
+    <label>
+      <%= f.check_box :requires_identifier %>
+      <%= Spree::Product.human_attribute_name(:requires_identifier) %>
+    </label>
+  <% end %>
+</div>

--- a/app/views/spree/admin/shipping_categories/_shipping_fields.html.erb
+++ b/app/views/spree/admin/shipping_categories/_shipping_fields.html.erb
@@ -1,0 +1,22 @@
+
+<div data-hook="shipping_type" class="field align-center">
+  <%= f.label :shipping_type %><br>
+  <%= f.select :shipping_type,
+                 Spree::ShippingCategory.shipping_types.keys.map { |k| [t("spree.shipping_types.#{k}"), k] },
+                 { include_blank: false },
+                 class: 'custom-select ' %>
+</div>
+<div data-hook="label_creation" class="field align-center">
+  <%= f.label :label_creation %><br>
+  <%= f.select :label_creation,
+                 Spree::ShippingCategory.label_creations.keys.map { |k| [t("spree.label_creations.#{k}"), k] },
+                 { include_blank: false },
+                 class: 'custom-select ' %>
+</div>
+<div data-hook="carrier_platform" class="field align-center">
+  <%= f.label :carrier_platform %><br>
+  <%= f.select :carrier_platform,
+                 Spree::ShippingCategory.carrier_platforms.keys.map { |k| [t("spree.carrier_platforms.#{k}"), k] },
+                 { include_blank: false },
+                 class: 'custom-select ' %>
+</div>

--- a/app/views/spree/admin/shipping_methods/_schedule_pickup.html.erb
+++ b/app/views/spree/admin/shipping_methods/_schedule_pickup.html.erb
@@ -1,0 +1,7 @@
+<%= f.field_container :schedule_pickup, class: %w(checkbox) do %>
+  <label>
+    <%= f.check_box(:schedule_pickup) %>
+    <%= Spree::ShippingMethod.human_attribute_name :schedule_pickup %>
+  </label>
+  <%= error_message_on :shipping_method, :schedule_pickup %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   spree:
     postage_label: 'Postage Label'
+    download_shipping_label: 'Download your Shipping Label'
     open_postage_label: 'Open'
     admin:
       postage_labels:

--- a/db/migrate/20250303075338_add_shipping_type_to_shipping_categories.rb
+++ b/db/migrate/20250303075338_add_shipping_type_to_shipping_categories.rb
@@ -1,0 +1,15 @@
+class AddShippingTypeToShippingCategories < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spree_shipping_categories, :carrier_platform, :integer,
+      default: 0,
+      comment: "Enum values: 0 = none, 1 = easypost"
+
+    add_column :spree_shipping_categories, :shipping_type, :integer,
+      default: 0,
+      comment: "Enum values: 0 = normal, 1 = advanced, 2 = roundtrip, 3= inbound, 4 = inboundroundtrip"
+
+    add_column :spree_shipping_categories, :label_creation, :integer,
+      default: 0,
+      comment: "Enum values: 0 = normal, 1 = advanced"
+  end
+end

--- a/db/migrate/20250304123225_add_schedule_pickup_in_shipping_method.rb
+++ b/db/migrate/20250304123225_add_schedule_pickup_in_shipping_method.rb
@@ -1,0 +1,5 @@
+class AddSchedulePickupInShippingMethod < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spree_shipping_methods, :schedule_pickup, :boolean, default: false
+  end
+end

--- a/db/migrate/20250304125214_add_requires_identifier_to_products.rb
+++ b/db/migrate/20250304125214_add_requires_identifier_to_products.rb
@@ -1,0 +1,7 @@
+class AddRequiresIdentifierToProducts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spree_products, :requires_identifier, :boolean,
+      default: false,
+      comment: 'Product requires an identifier'
+  end
+end

--- a/lib/generators/solidus_easypost/install/install_generator.rb
+++ b/lib/generators/solidus_easypost/install/install_generator.rb
@@ -6,6 +6,7 @@ module SolidusEasypost
       source_root File.expand_path('templates', __dir__)
 
       class_option :auto_run_migrations, type: :boolean, default: false
+      class_option :frontend, type: :string, default: 'starter'
 
       def copy_initializer
         template 'initializer.rb', 'config/initializers/solidus_easypost.rb'
@@ -17,6 +18,20 @@ module SolidusEasypost
 
       def add_javascripts
         empty_directory 'app/assets/javascripts'
+      end
+
+      def add_shipping_info
+        return if options[:frontend] != 'starter'
+
+        insert_into_file "app/views/orders/_order_shipments.html.erb",
+          "  <%= render 'orders/shared/shipping_label', order: order%> \n      ",
+          before: '</li>'
+        insert_into_file "app/views/cart_line_items/_product_submit.html.erb",
+          "  <%= render 'products/serial_number_label', product: product %> \n      ",
+          after: "<%= render 'cart_line_items/product_availability', product: product %>\n"
+        insert_into_file "app/views/checkouts/steps/delivery_step/_shipping_methods.html.erb",
+          "\n<%= render 'checkouts/steps/delivery_step/pickup_fields', form: form %>",
+          after: "</ul>"
       end
 
       def run_migrations

--- a/lib/solidus_easypost/calculator/weight_dimension_calculator.rb
+++ b/lib/solidus_easypost/calculator/weight_dimension_calculator.rb
@@ -11,11 +11,25 @@ module SolidusEasypost
       end
 
       def compute_for_package(package)
-        total_weight = package.contents.sum do |item|
-          item.quantity * item.variant.weight
+        total_weight = 0.0
+        total_height = 0.0
+        max_width = 0.0
+        max_depth = 0.0
+
+        package.contents.each do |item|
+          variant = item.variant
+          total_weight += variant.weight * item.quantity
+          total_height += variant.height * item.quantity
+          max_width = [max_width, variant.width].max
+          max_depth = [max_depth, variant.depth].max
         end
 
-        SolidusEasypost::ParcelDimension.new(weight: total_weight)
+        SolidusEasypost::ParcelDimension.new(
+          weight: total_weight,
+          height: total_height,
+          width: max_width,
+          depth: max_depth
+        )
       end
     end
   end

--- a/spec/models/spree/shipping_category_spec.rb
+++ b/spec/models/spree/shipping_category_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe Spree::ShippingCategory do
+  describe 'shipping type' do
+    it 'has the correct enum definition' do
+      expect(described_class.shipping_types).to eq(
+        'normal' => 0,
+        'advanced' => 1,
+        'roundtrip' => 2,
+        'inbound' => 3,
+        'inboundroundtrip' => 4
+      )
+    end
+
+    it 'defaults to shipping type' do
+      shipping_category = described_class.new
+      expect(shipping_category.shipping_type).to eq('normal')
+    end
+  end
+
+  describe 'carrier platform' do
+    it 'has the correct enum definition' do
+      expect(described_class.carrier_platforms).to eq(
+        'none' => 0,
+        'easypost' => 1
+      )
+    end
+
+    it 'defaults to carrier platform' do
+      shipping_category = described_class.new
+      expect(shipping_category.carrier_platform).to eq('none')
+    end
+  end
+
+  describe 'label creation' do
+    it 'has the correct enum definition' do
+      expect(described_class.label_creations).to eq(
+        'normal' => 0,
+        'advanced' => 1
+      )
+    end
+
+    it 'defaults to label creation' do
+      shipping_category = described_class.new
+      expect(shipping_category.label_creation).to eq('normal')
+    end
+  end
+end


### PR DESCRIPTION
This PR Bugfixes several issues around Easypost such as: 
- dimensions not passed correctly
- enable various shipment categories
- allow scheduling pickups

The full information is contained in the respective commits.
Closes #3 #4 