### PR TITLE
Add order type and improve payment validation for trade-in orders

### DIFF
--- a/app/decorators/models/solidus_easypost/spree/order_decorator.rb
+++ b/app/decorators/models/solidus_easypost/spree/order_decorator.rb
@@ -3,6 +3,7 @@
 module Spree
   module OrderDecorator
     def self.prepended(base)
+      base.state_machine.before_transition to: :complete, do: :set_order_type
       base.state_machine.after_transition to: :complete, do: :generate_labels
     end
 
@@ -10,22 +11,16 @@ module Spree
       # First, check the existing condition: if total is 0 or less, no payment is needed.
       return false unless total > 0
 
-      # Collect all products from the order's line items.
-      products = line_items.map { |li| li.variant.product }
-
-      # Check if any product has a product_type value of 2 (trade-in).
-      trade_in_present = products.any?(&:trade_in?)
-
       # Check if any product has a product_type value that is not 2.
       other_product_present = products.any? { |product| !product.trade_in? }
 
       # If both trade-in and non trade-in products are present, raise an error.
-      if trade_in_present && other_product_present
+      if trade_in_order? && other_product_present
         raise "Invalid order: cannot mix trade-in and non trade-in products."
       end
 
       # If only trade-in products are present, payment is not required.
-      return false if trade_in_present
+      return false if trade_in_order?
 
       # Otherwise, payment is required.
       true
@@ -36,6 +31,17 @@ module Spree
     def generate_labels
       shipments.each(&:label_for_complete_order)
       shipments.each(&:generate_inbound_roundtrip_labels)
+    end
+
+    def set_order_type
+      return unless trade_in_order?
+
+      customer_metadata["order_type"] = 'Trade-In'
+    end
+
+    def trade_in_order?
+      # Collect all products from the order's line items and check if any product is a trade-in.
+      line_items.any? { |li| li.variant.product.trade_in? }
     end
   end
 end


### PR DESCRIPTION
#### Summary

This PR introduces enhancements to the handling of trade-in orders in the Solidus application. It adds a new method to set the order type in customer metadata and refactors the payment validation logic to ensure proper handling of trade-in products.

#### Changes

1. **Added `set_order_type` method**:
2. **Refactored `payment_required?` method**:
3. **Introduced `trade_in_order?` method**:
4. **Ensured that mixing trade-in and non trade-in products raises an error**
5. **Updated the state machine**:
   - The state machine now calls the `set_order_type` method before transitioning to the complete state.

#### Screenshot

![image](https://github.com/user-attachments/assets/62fe8336-b470-4e1c-aece-c540ac1d01ae)
