### PR TITLE
Fix line item meta data overwrite

### DIFF
--- a/app/decorators/controllers/cart_line_items_controller_decorator.rb
+++ b/app/decorators/controllers/cart_line_items_controller_decorator.rb
@@ -1,48 +1,46 @@
 # frozen_string_literal: true
 
-module Spree
-  module Api
-    module CartLineItemsControllerDecorator
-      def create
-        @order = current_order(create_order_if_necessary: true)
-        authorize! :update, @order, cookies.signed[:guest_token]
+module CartLineItemsControllerDecorator
+  def create
+    @order = current_order(create_order_if_necessary: true)
+    authorize! :update, @order, cookies.signed[:guest_token]
 
-        variant  = Spree::Variant.find(params[:variant_id])
-        quantity = params[:quantity].present? ? params[:quantity].to_i : 1
+    variant  = Spree::Variant.find(params[:variant_id])
+    quantity = params[:quantity].present? ? params[:quantity].to_i : 1
 
-        customer_metadata = params.require(:customer_metadata).permit! if params[:customer_metadata].present?
-        # 2,147,483,647 is crazy. See issue https://github.com/spree/spree/issues/2695.
-        if quantity.between?(1, 2_147_483_647)
-          begin
-            @line_item = @order.contents.add(variant, quantity)
-            if customer_metadata.present?
-              customer_metadata.each do |key, value|
-                unique_key = "#{key}_#{SecureRandom.hex(4)}"
-                @line_item.customer_metadata[unique_key] = value
-              end
-              @line_item.save
-            end
-          rescue ActiveRecord::RecordInvalid => e
-            @order.errors.add(:base, e.record.errors.full_messages.join(", "))
+    customer_metadata = params.require(:customer_metadata).permit! if params[:customer_metadata].present?
+    # 2,147,483,647 is crazy. See issue https://github.com/spree/spree/issues/2695.
+    if quantity.between?(1, 2_147_483_647)
+      begin
+        @line_item = @order.contents.add(variant, quantity)
+        if customer_metadata.present?
+          customer_metadata.each do |key, value|
+            next unless key == "line_item_identifier"
+
+            @line_item.customer_metadata[key] ||= []
+            @line_item.customer_metadata[key] << value
           end
-        else
-          @order.errors.add(:base, t('spree.please_enter_reasonable_quantity'))
+          @line_item.save
         end
+      rescue ActiveRecord::RecordInvalid => e
+        @order.errors.add(:base, e.record.errors.full_messages.join(", "))
+      end
+    else
+      @order.errors.add(:base, t('spree.please_enter_reasonable_quantity'))
+    end
 
-        respond_to do |format|
-          format.html do
-            if @order.errors.any?
-              flash[:error] = @order.errors.full_messages.join(", ")
-              redirect_back_or_default(root_path)
-              return
-            else
-              redirect_to cart_path
-            end
-          end
+    respond_to do |format|
+      format.html do
+        if @order.errors.any?
+          flash[:error] = @order.errors.full_messages.join(", ")
+          redirect_back_or_default(root_path)
+          return
+        else
+          redirect_to cart_path
         end
       end
     end
   end
 end
 
-CartLineItemsController.prepend(Spree::Api::CartLineItemsControllerDecorator)
+CartLineItemsController.prepend(CartLineItemsControllerDecorator)

--- a/app/overrides/solidus_easypost/add_require_identifier_to_product_form.rb
+++ b/app/overrides/solidus_easypost/add_require_identifier_to_product_form.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module SolidusEasypost
-  module AddRequiresIdentifierToProductForm
+  module AddRequireIdentifierToProductForm
     Deface::Override.new(
       virtual_path: 'spree/admin/products/_form',
-      name: 'add_requires_identifier_field',
+      name: 'add_require_line_item_identifier_field',
       insert_after: "[data-hook='admin_product_form_track_inventory']",
-      partial: 'spree/admin/products/product_require_identifier_field'
+      partial: 'spree/admin/products/product_require_line_item_identifier_field'
     )
   end
 end

--- a/app/views/products/_serial_number_label.html.erb
+++ b/app/views/products/_serial_number_label.html.erb
@@ -1,5 +1,5 @@
-<% if product.requires_identifier %>
+<% if product.require_line_item_identifier %>
   <%= label_tag :customer_metadata_value, "Serial Number or IMEI" %>
   <p>Note: If you want the shipment to be insured, please provide a Serial Number or IMEI for your product.</p>
-  <%= text_field_tag "customer_metadata[user_serial_number]", nil, placeholder: "Enter IMEI", class: 'min-w-[200px] mb-5' %>
+  <%= text_field_tag "customer_metadata[line_item_identifier]", nil, placeholder: "Enter IMEI", class: 'min-w-[200px] mb-5' %>
 <% end %>

--- a/app/views/spree/admin/products/_product_require_identifier_field.html.erb
+++ b/app/views/spree/admin/products/_product_require_identifier_field.html.erb
@@ -1,8 +1,0 @@
-<div data-hook="admin_product_form_track_inventory">
-  <%= f.field_container :requires_identifier do %>
-    <label>
-      <%= f.check_box :requires_identifier %>
-      <%= Spree::Product.human_attribute_name(:requires_identifier) %>
-    </label>
-  <% end %>
-</div>

--- a/app/views/spree/admin/products/_product_require_line_item_identifier_field.html.erb
+++ b/app/views/spree/admin/products/_product_require_line_item_identifier_field.html.erb
@@ -1,0 +1,8 @@
+<div data-hook="admin_product_form_track_inventory">
+  <%= f.field_container :require_line_item_identifier do %>
+    <label>
+      <%= f.check_box :require_line_item_identifier %>
+      <%=  t('spree.require_line_item_identifier')  %>
+    </label>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
     default_stock_location: "Default Location"
     return_stock_location: "Return Location"
     service_stock_location: "Service Location"
+    require_line_item_identifier: "Require Line Item Identifier"
     product_types:
       standard: "Standard Product"
       service: "Service"

--- a/db/migrate/20250304125214_add_require_identifier_to_products.rb
+++ b/db/migrate/20250304125214_add_require_identifier_to_products.rb
@@ -1,0 +1,7 @@
+class AddRequireIdentifierToProducts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spree_products, :require_line_item_identifier, :boolean,
+      default: false,
+      comment: 'Product require an Line Item identifier'
+  end
+end

--- a/db/migrate/20250304125214_add_requires_identifier_to_products.rb
+++ b/db/migrate/20250304125214_add_requires_identifier_to_products.rb
@@ -1,7 +1,0 @@
-class AddRequiresIdentifierToProducts < ActiveRecord::Migration[7.2]
-  def change
-    add_column :spree_products, :requires_identifier, :boolean,
-      default: false,
-      comment: 'Product requires an identifier'
-  end
-end


### PR DESCRIPTION
- Updated the logic to handle `line_item_identifier` in customer metadata.
- Ensured that `line_item_identifier` is stored as an array in the line item's customer metadata.
- Removed the generation of unique keys for `line_item_identifier`.

This change ensures that the `line_item_identifier` is correctly stored as an array in the line item's customer metadata, allowing multiple serial numbers to be associated with a single line item.

![image](https://github.com/user-attachments/assets/646dce78-5292-416e-af2a-6e04a18fd379)
![image](https://github.com/user-attachments/assets/57d9dc7b-f6a3-4f22-a1f8-200b8a0c5695)

