### PR TITLE
Add payment information fields

### DIFF
--- a/app/decorators/controllers/checkouts_controller_decorator.rb
+++ b/app/decorators/controllers/checkouts_controller_decorator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module CheckoutsControllerDecorator
+  def update_params
+    case params[:state].to_sym
+    when :address
+      massaged_params.require(:order).permit(
+        permitted_checkout_address_attributes
+      )
+    when :delivery
+      massaged_params.require(:order).permit(
+        permitted_checkout_delivery_attributes + [customer_metadata: {}]
+      )
+    when :payment
+      if @order.covered_by_store_credit?
+        massaged_params.fetch(:order, {})
+      else
+        massaged_params.require(:order)
+      end.permit(
+        permitted_checkout_payment_attributes
+      )
+    else
+      massaged_params.fetch(:order, {}).permit(
+        permitted_checkout_confirm_attributes
+      )
+    end
+  end
+end
+
+CheckoutsController.prepend(CheckoutsControllerDecorator)

--- a/app/decorators/models/solidus_easypost/spree/order_decorator.rb
+++ b/app/decorators/models/solidus_easypost/spree/order_decorator.rb
@@ -26,6 +26,11 @@ module Spree
       true
     end
 
+    def trade_in_order?
+      # Collect all products from the order's line items and check if any product is a trade-in.
+      line_items.any? { |li| li.variant.product.trade_in? }
+    end
+
     private
 
     def generate_labels
@@ -37,11 +42,6 @@ module Spree
       return unless trade_in_order?
 
       customer_metadata["order_type"] = 'Trade-In'
-    end
-
-    def trade_in_order?
-      # Collect all products from the order's line items and check if any product is a trade-in.
-      line_items.any? { |li| li.variant.product.trade_in? }
     end
   end
 end

--- a/app/views/checkouts/steps/delivery_step/_order_metadata_fields.html.erb
+++ b/app/views/checkouts/steps/delivery_step/_order_metadata_fields.html.erb
@@ -1,0 +1,5 @@
+  <%= form_with model: @order, local: true do |form| %>
+    <%= form.fields_for :customer_metadata, @order.customer_metadata || {}, builder: ActionView::Helpers::FormBuilder do |meta| %>
+        <%= render 'checkouts/steps/delivery_step/shared/payment_info_fields', form: form, meta: meta %>
+    <% end %>
+  <% end %>

--- a/app/views/checkouts/steps/delivery_step/_pickup_fields.html.erb
+++ b/app/views/checkouts/steps/delivery_step/_pickup_fields.html.erb
@@ -53,3 +53,5 @@
     </div>
   </div>
 <% end %>
+
+<%= render 'checkouts/steps/delivery_step/order_metadata_fields', form: form %>

--- a/app/views/checkouts/steps/delivery_step/shared/_payment_info_fields.html.erb
+++ b/app/views/checkouts/steps/delivery_step/shared/_payment_info_fields.html.erb
@@ -1,0 +1,26 @@
+<% if form.object.trade_in_order? %>
+  <div class="flex flex-col gap-y-3 pb-6 border-b-[1px] md:gap-y-6">
+    <legend class="font-serif text-h5 md:text-h4">
+      <%= t('spree.trade_in_payment_info') %>
+    </legend>
+    <%= label_tag :payment_method,  "#{I18n.t("spree.insert_payment_information")}" %>
+    <% ['Bank Transfer', 'PayPal', 'Not Now'].each do |method| %>
+      <div class="radio-input flex gap-x-3 items-center last:mb-0">
+        <%= meta.label :payment_method, class: "radio-input flex gap-x-3 items-center last:mb-0" do %>
+          <%= meta.radio_button :payment_method, method, checked: @order.customer_metadata["payment_method"] == method %>
+          <%= method %>
+        <% end %>
+      </div>
+    <% end %>
+
+    <div class="text-input">
+      <%= meta.label :account_holder, "#{I18n.t("spree.account_holder")}:" %>
+      <%= meta.text_field :account_holder, value: @order.customer_metadata["account_holder"] %>
+    </div>
+
+    <div class="text-input">
+      <%= meta.label :payment_account, "#{I18n.t("spree.payment_account")}:" %>
+      <%= meta.text_field :payment_account, value: @order.customer_metadata["payment_account"] %>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,10 @@ en:
     next_5_business_days: "Next 5 Business Days"
     available_time_slots: "Available Time Slots"
     schedule_pickup: "Schedule Pickup"
+    trade_in_payment_info: "Trade-In Payment Information"
+    account_holder: "Account Holder"
+    payment_account: "Payment Account"
+    insert_payment_information: "Please specify how you want to get paid. Please note that you can communicate your choice later, but it may delay your Trade-In."
     product_types:
       standard: "Standard Product"
       service: "Service"

--- a/lib/generators/solidus_easypost/install/install_generator.rb
+++ b/lib/generators/solidus_easypost/install/install_generator.rb
@@ -18,6 +18,8 @@ module SolidusEasypost
 
       def add_javascripts
         empty_directory 'app/assets/javascripts'
+        template 'payment_info_toggle.js', 'app/assets/javascripts/payment_info_toggle.js'
+        append_file 'app/assets/javascripts/solidus_starter_frontend.js', "//= require payment_info_toggle\n"
       end
 
       def add_shipping_info

--- a/lib/generators/solidus_easypost/install/templates/payment_info_toggle.js
+++ b/lib/generators/solidus_easypost/install/templates/payment_info_toggle.js
@@ -1,0 +1,40 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const paymentMethodRadios = document.querySelectorAll('input[name="order[customer_metadata][payment_method]"]');
+  const accountHolderField = document.getElementById('order_customer_metadata_account_holder');
+  const paymentAccountField = document.getElementById('order_customer_metadata_payment_account');
+  const accountHolderLabel = document.querySelector('label[for="order_customer_metadata_account_holder"]');
+  const paymentAccountLabel = document.querySelector('label[for="order_customer_metadata_payment_account"]');
+
+  function togglePaymentFields() {
+      const selectedMethod = document.querySelector('input[name="order[customer_metadata][payment_method]"]:checked');
+      if (selectedMethod) {
+          const selectedMethodValue = selectedMethod.value;
+          if (accountHolderField && paymentAccountField && accountHolderLabel && paymentAccountLabel) {
+              if (selectedMethodValue === 'Not Now') {
+                  accountHolderField.style.display = 'none';
+                  paymentAccountField.style.display = 'none';
+                  accountHolderLabel.style.display = 'none';
+                  paymentAccountLabel.style.display = 'none';
+              } else {
+                  accountHolderField.style.display = 'block';
+                  paymentAccountField.style.display = 'block';
+                  accountHolderLabel.style.display = 'block';
+                  paymentAccountLabel.style.display = 'block';
+              }
+          }
+      } else {
+          if (accountHolderField && paymentAccountField && accountHolderLabel && paymentAccountLabel) {
+              accountHolderField.style.display = 'none';
+              paymentAccountField.style.display = 'none';
+              accountHolderLabel.style.display = 'none';
+              paymentAccountLabel.style.display = 'none';
+          }
+      }
+  }
+
+  paymentMethodRadios.forEach(radio => {
+      radio.addEventListener('change', togglePaymentFields);
+  });
+
+  togglePaymentFields();
+});


### PR DESCRIPTION
This pull request includes several enhancements and updates related to the handling of trade-in orders, specifically focusing on adding payment information fields and improving parameter handling in the checkout process.

#### Changes Included:

1. **Update Order Decorator to Refactor `trade_in_order?` Method**:
   - Moved the `trade_in_order?` method to the public section of the class for better accessibility.
   - This refactoring ensures that the method is easily accessible for checking if an order contains trade-in products.

2. **Add Controller Decorator for Checkout Params Handling**:
   - Added a new decorator for the `CheckoutsController` to handle permitted parameters based on the checkout state.
   - Included customer metadata in the permitted parameters for the delivery state.
   - This update ensures that the necessary parameters are correctly handled during the checkout process.

3. **Add Payment Info Fields Partial for Trade-In Orders**:
   - Created a new partial to render payment information fields specifically for trade-in orders.
   - Included fields for payment method, account holder, and payment account.
   - Added a legend for better section identification.
   - Updated labels and select inputs to use localized strings.
   - This enhancement improves the user experience by providing a clear and organized way to input payment information for trade-in orders.

These changes enhance the functionality and user experience for trade-in orders by ensuring proper parameter handling and providing a dedicated section for entering payment information.
![paymenet info](https://github.com/user-attachments/assets/0929e289-e5d4-487f-b81e-c7a6c9bda68b)
![payment info with shipping](https://github.com/user-attachments/assets/616111c8-9871-4f6c-9af4-e7734c205831)
