### PR TITLE
Add customer_reference for Orders with Company Addresses

### DIFF
--- a/app/views/checkouts/steps/delivery_step/_order_metadata_fields.html.erb
+++ b/app/views/checkouts/steps/delivery_step/_order_metadata_fields.html.erb
@@ -1,5 +1,6 @@
-  <%= form_with model: @order, local: true do |form| %>
-    <%= form.fields_for :customer_metadata, @order.customer_metadata || {}, builder: ActionView::Helpers::FormBuilder do |meta| %>
-        <%= render 'checkouts/steps/delivery_step/shared/payment_info_fields', form: form, meta: meta %>
-    <% end %>
+<%= form_with model: @order, local: true do |form| %>
+  <%= form.fields_for :customer_metadata, @order.customer_metadata || {}, builder: ActionView::Helpers::FormBuilder do |meta| %>
+    <%= render 'checkouts/steps/delivery_step/shared/payment_info_fields', form: form, meta: meta %>
+    <%= render 'checkouts/steps/delivery_step/shared/customer_reference_field', form: form, meta: meta %>
   <% end %>
+<% end %>

--- a/app/views/checkouts/steps/delivery_step/shared/_customer_reference_field.html.erb
+++ b/app/views/checkouts/steps/delivery_step/shared/_customer_reference_field.html.erb
@@ -1,0 +1,16 @@
+<% if form.object.bill_address.company.present? || form.object.ship_address.company.present? %>
+  <% if form.object.trade_in_order? %>
+    <div class="flex flex-col gap-y-3 py-7 mb-7 pb-6 border-b-[1px] md:gap-y-6">
+  <% else %>
+    <div class="flex flex-col gap-y-3 pb-6 border-b-[1px] md:gap-y-6">
+  <% end %>
+
+    <legend class="font-serif text-h5 md:text-h4">
+      <%= t('spree.reference_number') %>
+    </legend>
+    <div class="text-input">
+      <%= meta.label :customer_reference, "#{I18n.t('spree.customer_reference')}:", class: "block font-medium mb-1" %>
+      <%= meta.text_field :customer_reference, value: @order.customer_metadata["customer_reference"] %>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,8 @@ en:
     account_holder: "Account Holder"
     payment_account: "Payment Account"
     insert_payment_information: "Please specify how you want to get paid. Please note that you can communicate your choice later, but it may delay your Trade-In."
+    reference_number: "Reference Number"
+    customer_reference: "Your Reference (PO-Number, Asset Number,…)"
     product_types:
       standard: "Standard Product"
       service: "Service"


### PR DESCRIPTION
- Updated the order metadata fields partial to include a PO number field.
- Created a new partial for the PO number field, which is displayed if the billing or shipping address includes a company.
- Added localization strings for reference number and PO number.

![only po num](https://github.com/user-attachments/assets/f2290cd7-dced-452f-bbd3-ef8349f574df)
![po and info](https://github.com/user-attachments/assets/0f14537f-ae7b-479c-bcdb-8037dc7cd973)
![po num without pickup fields](https://github.com/user-attachments/assets/d050bca8-4565-4e9f-81e7-c2c101ca81b1)
![po nm not trade](https://github.com/user-attachments/assets/427c1896-31ce-42ec-8adc-f6e333e07a43)
![po num all f](https://github.com/user-attachments/assets/418e20af-0cad-49b6-9fb9-09960f0d8530)
![image](https://github.com/user-attachments/assets/d14fafaa-80b3-4363-96d3-2175bb73718d)


