### PR TITLE
Use default shipping calculator instead of easypost rate

### DIFF
--- a/app/overrides/solidus_easypost/add_default_shipping_calculator_form.rb
+++ b/app/overrides/solidus_easypost/add_default_shipping_calculator_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SolidusEasypost
+  module AddDefaultShippingCalculatorForm
+    Deface::Override.new(
+      virtual_path: 'spree/admin/shipping_methods/_form',
+      name: 'add_default_shipping_calculator',
+      insert_after: "[data-hook='admin_shipping_method_form_fields']",
+      partial: 'spree/admin/shipping_methods/default_shipping_calculator'
+    )
+  end
+end

--- a/app/views/spree/admin/shipping_methods/_default_shipping_calculator.html.erb
+++ b/app/views/spree/admin/shipping_methods/_default_shipping_calculator.html.erb
@@ -1,0 +1,7 @@
+<%= f.field_container :use_default_shipping_calculator, class: %w(checkbox) do %>
+  <label>
+    <%= f.check_box(:use_default_shipping_calculator) %>
+    <%= Spree::ShippingMethod.human_attribute_name :use_default_shipping_calculator %>
+  </label>
+  <%= error_message_on :shipping_method, :use_default_shipping_calculator %>
+<% end %>

--- a/db/migrate/20250311143522_add_default_shipping_calculator_to_shipping_method.rb
+++ b/db/migrate/20250311143522_add_default_shipping_calculator_to_shipping_method.rb
@@ -1,0 +1,5 @@
+class AddDefaultShippingCalculatorToShippingMethod < ActiveRecord::Migration[8.0]
+  def change
+    add_column :spree_shipping_methods, :use_default_shipping_calculator, :boolean, default: false
+  end
+end

--- a/lib/solidus_easypost/estimator.rb
+++ b/lib/solidus_easypost/estimator.rb
@@ -5,7 +5,7 @@ module SolidusEasypost
     def shipping_rates(package, _frontend_only = true)
       easypost_rates = ShipmentBuilder.from_package(package).rates.sort_by(&:rate)
 
-      shipping_rates = easypost_rates.map { |rate| build_shipping_rate(rate) }.compact
+      shipping_rates = easypost_rates.filter_map { |rate| build_shipping_rate(package, rate) }
       shipping_rates.min_by(&:cost)&.selected = true
 
       shipping_rates
@@ -13,16 +13,16 @@ module SolidusEasypost
 
     private
 
-    def build_shipping_rate(rate)
+    def build_shipping_rate(package, rate)
       shipping_method = shipping_method_selector.shipping_method_for(rate)
       return unless shipping_method.available_to_users?
 
       ::Spree::ShippingRate.new(
         name: "#{rate.carrier} #{rate.service}",
-        cost: shipping_rate_calculator.compute(rate),
+        cost: shipping_rate_calculator.compute(package, rate, shipping_method),
         easy_post_shipment_id: rate.shipment_id,
         easy_post_rate_id: rate.id,
-        shipping_method: shipping_method,
+        shipping_method: shipping_method
       )
     end
 

--- a/lib/solidus_easypost/shipping_rate_calculator.rb
+++ b/lib/solidus_easypost/shipping_rate_calculator.rb
@@ -2,8 +2,15 @@
 
 module SolidusEasypost
   class ShippingRateCalculator
-    def compute(rate)
-      rate.rate
+    def compute(package, rate, shipping_method)
+      shipping_method.use_default_shipping_calculator ? calculate_with_default(package, shipping_method) : rate.rate
+    end
+
+    private
+
+    def calculate_with_default(package, shipping_method)
+      # Use the default shipping calculator logic
+      shipping_method.calculator.compute(package)
     end
   end
 end


### PR DESCRIPTION
This PR targets resolving [issue#33](https://github.com/S3-Store/s3_easypost_advanced/issues/33) with following approach
- Introduced a new column use_default_shipping_calculator
- If its true then use the default shipping calculator (from solidus core)
- if its false then use current calculator
