### PR TITLE
Add reference field to shipment creation in SolidusEasypost

### DIFF
--- a/lib/solidus_easypost/shipment_builder.rb
+++ b/lib/solidus_easypost/shipment_builder.rb
@@ -9,6 +9,7 @@ module SolidusEasypost
           to_address: AddressBuilder.from_address(package.order.ship_address, to_address || {}),
           from_address: AddressBuilder.from_stock_location(package.stock_location, from_address || {}),
           parcel: ParcelBuilder.from_package(package),
+          reference: build_reference(package),
           options: options
         )
       end
@@ -38,6 +39,13 @@ module SolidusEasypost
         from_address = options.delete(:from_address_options)
         to_address = options.delete(:to_address_options)
         [from_address, to_address]
+      end
+
+      def build_reference(package)
+        reference = package.order.number
+        customer_reference = package.order.customer_metadata['customer_reference']
+        reference += " #{customer_reference}" if customer_reference.present?
+        reference
       end
     end
   end


### PR DESCRIPTION
Introduced a new `reference` field to the shipment creation process in the `SolidusEasypost::ShipmentBuilder` class. The `reference` is built using the order number and an optional customer reference from the order's metadata. This enhancement allows for better tracking and identification of shipments by including additional contextual information in the reference field.

Resolves: https://github.com/S3-Store/s3_easypost_advanced/issues/12